### PR TITLE
Edit invalid environment parameters in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ The `bitnami/phppgadmin:latest` tag always points to the most recent release. To
 The phpPgAdmin instance can be customized by specifying environment variables on the first run. The following environment values are provided to custom phpPgAdmin:
 
 - `DATABASE_ENABLE_EXTRA_LOGIN_SECURITY`: Whether to enable extra login security. When enabled, logins with no password or certain usernames (postgres, root, pgsql, administrator) will be denied. Default: **no**
-- `DATABASE_HOST`: Database server host. Default: **postgresql**.
-- `DATABASE_PORT_NUMBER`: Database server port. Default: **5432**
+- `POSTGRESQL_HOST`: Database server host. Default: **postgresql**.
+- `POSTGRESQL_PORT_NUMBER`: Database server port. Default: **5432**
 - `DATABASE_SSL_MODE`: Database SSL mode. Supported options are: disable, allow, prefer, require. No default.
 - `PHP_UPLOAD_MAX_FILESIZE`: Max PHP upload file size. Default: **80M**
 - `PHP_POST_MAX_SIZE`: Max PHP POST size. Default: **80M**


### PR DESCRIPTION
Your Dockefile contains environment variables:
```
    POSTGRESQL_CLIENT_CREATE_DATABASE_NAME="" \
    POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD="" \
    POSTGRESQL_CLIENT_CREATE_DATABASE_USERNAME="" \
    POSTGRESQL_HOST="postgresql" \
    POSTGRESQL_PORT_NUMBER="5432" \

```
However, here you proposing to use the other. Changed to these in Dockerfile and it worked.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
