### PR TITLE
Explicitly reference DATABASE_HOST environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ services:
       - 'postgresql_data:/bitnami'
   phppgadmin:
     build: .
+    environment:
+      - DATABASE_HOST=postgresql
     ports:
       - '80:8181'
       - '443:8143'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - 'postgresql_data:/bitnami'
   phppgadmin:
     image: docker.io/bitnami/phppgadmin:7
+    environment:
+      - DATABASE_HOST=postgresql
     ports:
       - '80:8080'
       - '443:8443'


### PR DESCRIPTION
**Description of the change**
Explicitly reference DATABASE_HOST environment variable in docker-compose.yml and README.md.

**Benefits**
Makes it less likely, that users who are not developers at this repository accidentally break the connection between the phppgadmin and postgresql containers when renaming the postgresql container to something other than "postgresql".

**Possible drawbacks**
One more line in both README.md and docker-compose.yml.
Slightly more verbose for advanced users and developers.

**Applicable issues**
Partly solves #6.